### PR TITLE
Set up piwik analytics with fake urls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ courts_data/*
 data/*
 output/*
 processed/*
+*.swp
+.ve

--- a/generate_html.py
+++ b/generate_html.py
@@ -1,4 +1,5 @@
 from jinja2 import Environment, FileSystemLoader 
+import datetime
 import json
 import sys
 env = Environment(loader=FileSystemLoader('templates'), autoescape=True)
@@ -18,11 +19,22 @@ with open("processed/area_matches.json") as area_matches_file:
     area_matches = json.load(area_matches_file)
 
 with open('output/areas.html', 'w+') as name_output:
-    name_output.write(area_template.render(templates=templates, area_matches=area_matches, user=user))
+    name_output.write(area_template.render(
+        templates=templates,
+        area_matches=area_matches,
+        user=user,
+        date=datetime.date.today().isoformat(),
+    ))
 
 with open("processed/interesting_names.json") as interesting_names_file:
     interesting_names = json.load(interesting_names_file)
 
 with open('output/names.html', 'w+') as name_output:
-    name_output.write(names_template.render(templates=templates, interesting_names=interesting_names, interesting_names_json=json.dumps(interesting_names), user=user))
+    name_output.write(names_template.render(
+        templates=templates,
+        interesting_names=interesting_names,
+        interesting_names_json=json.dumps(interesting_names),
+        user=user,
+        date=datetime.date.today().isoformat(),
+    ))
 

--- a/generate_html.py
+++ b/generate_html.py
@@ -1,13 +1,7 @@
 from jinja2 import Environment, FileSystemLoader 
 import datetime
 import json
-import sys
 env = Environment(loader=FileSystemLoader('templates'), autoescape=True)
-
-if len(sys.argv) > 1:
-    user = sys.argv[1]
-else:
-    user = 'test'
 
 names_template = env.get_template('names.html')
 area_template = env.get_template('areas.html')
@@ -22,7 +16,6 @@ with open('output/areas.html', 'w+') as name_output:
     name_output.write(area_template.render(
         templates=templates,
         area_matches=area_matches,
-        user=user,
         date=datetime.date.today().isoformat(),
     ))
 
@@ -34,7 +27,6 @@ with open('output/names.html', 'w+') as name_output:
         templates=templates,
         interesting_names=interesting_names,
         interesting_names_json=json.dumps(interesting_names),
-        user=user,
         date=datetime.date.today().isoformat(),
     ))
 

--- a/generate_html.py
+++ b/generate_html.py
@@ -1,6 +1,12 @@
 from jinja2 import Environment, FileSystemLoader 
 import json
+import sys
 env = Environment(loader=FileSystemLoader('templates'), autoescape=True)
+
+if len(sys.argv) > 1:
+    user = sys.argv[1]
+else:
+    user = 'test'
 
 names_template = env.get_template('names.html')
 area_template = env.get_template('areas.html')
@@ -12,11 +18,11 @@ with open("processed/area_matches.json") as area_matches_file:
     area_matches = json.load(area_matches_file)
 
 with open('output/areas.html', 'w+') as name_output:
-    name_output.write(area_template.render(templates=templates, area_matches=area_matches))
+    name_output.write(area_template.render(templates=templates, area_matches=area_matches, user=user))
 
 with open("processed/interesting_names.json") as interesting_names_file:
     interesting_names = json.load(interesting_names_file)
 
 with open('output/names.html', 'w+') as name_output:
-    name_output.write(names_template.render(templates=templates, interesting_names=interesting_names, interesting_names_json=json.dumps(interesting_names)))
+    name_output.write(names_template.render(templates=templates, interesting_names=interesting_names, interesting_names_json=json.dumps(interesting_names), user=user))
 

--- a/templates/areas.html
+++ b/templates/areas.html
@@ -36,3 +36,8 @@
 </div>
 
 {% endblock %}
+
+{% block extrapiwik %}
+_paq.push(['setCustomUrl', 'local://areas.html']);
+_paq.push(['trackPageView']);
+{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -66,13 +66,11 @@
     <script type="text/javascript">
       var _paq = _paq || [];
       // Don't send the actual URL
-      _paq.push(['setCustomUrl', 'local://names.html/']);
+      _paq.push(['setCustomUrl', 'local://']);
       // Turn off link tracking for now, as it leaks the url
       //_paq.push(['enableLinkTracking']);
-      // A lot of events happen in the jinja template render instead of here
-      // accurately measure the time spent on the last pageview of a visit
-      _paq.push(['enableHeartBeatTimer']);
       _paq.push(['setUserId', '{{ user }}']);
+      // Note: A lot of events happen in the jinja template render instead of here
       (function() {
         var u="https://mon.opendataservices.coop/piwik/";
         _paq.push(['setTrackerUrl', u+'piwik.php']);

--- a/templates/base.html
+++ b/templates/base.html
@@ -62,4 +62,20 @@
     {% block modals %}
     {% endblock %}
 
+    <!-- Piwik -->
+    <script type="text/javascript">
+      var _paq = _paq || [];
+      _paq.push(["setDomains", ["*.example.com"]]);
+      _paq.push(['trackPageView']);
+      _paq.push(['enableLinkTracking']);
+      (function() {
+        var u="https://mon.opendataservices.coop/piwik/";
+        _paq.push(['setTrackerUrl', u+'piwik.php']);
+        _paq.push(['setSiteId', '10']);
+        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+        g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+      })();
+    </script>
+    <noscript><p><img src="https://mon.opendataservices.coop/piwik/piwik.php?idsite=10" style="border:0;" alt="" /></p></noscript>
+    <!-- End Piwik Code -->
 </html>

--- a/templates/base.html
+++ b/templates/base.html
@@ -69,7 +69,6 @@
       _paq.push(['setCustomUrl', 'local://']);
       // Turn off link tracking for now, as it leaks the url
       //_paq.push(['enableLinkTracking']);
-      _paq.push(['setUserId', '{{ user }}']);
       // Note: A lot of events happen in the jinja template render instead of here
       (function() {
         var u="https://mon.opendataservices.coop/piwik/";

--- a/templates/base.html
+++ b/templates/base.html
@@ -65,9 +65,13 @@
     <!-- Piwik -->
     <script type="text/javascript">
       var _paq = _paq || [];
-      _paq.push(["setDomains", ["*.example.com"]]);
-      _paq.push(['trackPageView']);
-      _paq.push(['enableLinkTracking']);
+      // Don't send the actual URL
+      _paq.push(['setCustomUrl', 'local://names.html/']);
+      // Turn off link tracking for now, as it leaks the url
+      //_paq.push(['enableLinkTracking']);
+      // A lot of events happen in the jinja template render instead of here
+      // accurately measure the time spent on the last pageview of a visit
+      _paq.push(['enableHeartBeatTimer']);
       (function() {
         var u="https://mon.opendataservices.coop/piwik/";
         _paq.push(['setTrackerUrl', u+'piwik.php']);

--- a/templates/base.html
+++ b/templates/base.html
@@ -72,6 +72,7 @@
       // A lot of events happen in the jinja template render instead of here
       // accurately measure the time spent on the last pageview of a visit
       _paq.push(['enableHeartBeatTimer']);
+      _paq.push(['setUserId', '{{ user }}']);
       (function() {
         var u="https://mon.opendataservices.coop/piwik/";
         _paq.push(['setTrackerUrl', u+'piwik.php']);

--- a/templates/base.html
+++ b/templates/base.html
@@ -69,7 +69,9 @@
       _paq.push(['setCustomUrl', 'local://']);
       // Turn off link tracking for now, as it leaks the url
       //_paq.push(['enableLinkTracking']);
-      // Note: A lot of events happen in the jinja template render instead of here
+      _paq.push(['setCustomDimension', customDimensionId=4, customDimensionValue='{{ date }}']);
+      {% block extrapiwik %}{% endblock %}
+      // Note: A lot of events happen in the names.html rerender function instead of here
       (function() {
         var u="https://mon.opendataservices.coop/piwik/";
         _paq.push(['setTrackerUrl', u+'piwik.php']);

--- a/templates/names.html
+++ b/templates/names.html
@@ -174,20 +174,20 @@ $(function () {
     $("#main").append(res)
 
 
-    if (fragment_obj.sources === undefined) {
-        var search_slug = 'nosearch';
-    } else {
+    if (fragment_obj.name_search) {
         var search_slug = 'search';
-    }
-    if (fragment_obj.wards === undefined) {
-        var wards_slug = '_';
     } else {
+        var search_slug = 'nosearch';
+    }
+    if (fragment_obj.wards) {
         var wards_slug = fragment_obj.wards.join();
-    }
-    if (fragment_obj.sources === undefined) {
-        var sources_slug = '_';
     } else {
+        var wards_slug = '_';
+    }
+    if (fragment_obj.sources) {
         var sources_slug = fragment_obj.sources.join();
+    } else {
+        var sources_slug = '_';
     }
     // Track a fake url for this page in piwik
     _paq.push(['setCustomUrl', 'local://names.html/' + search_slug + '/' + wards_slug + '/' + sources_slug + '/page=' + current_page]);

--- a/templates/names.html
+++ b/templates/names.html
@@ -192,7 +192,6 @@ $(function () {
     _paq.push(['setCustomDimension', customDimensionId=1, customDimensionValue=wards_slug]);
     _paq.push(['setCustomDimension', customDimensionId=2, customDimensionValue=sources_slug]);
     _paq.push(['setCustomDimension', customDimensionId=3, customDimensionValue=search_slug]);
-    _paq.push(['setCustomDimension', customDimensionId=4, customDimensionValue='{{ date }}']);
     // Track a fake url for this page in piwik
     _paq.push(['setCustomUrl', 'local://names.html/' + search_slug + '/' + wards_slug + '/' + sources_slug + '/page=' + current_page]);
     _paq.push(['trackPageView']);

--- a/templates/names.html
+++ b/templates/names.html
@@ -173,6 +173,9 @@ $(function () {
     var res = nunjucks.render('pager.html', context);
     $("#main").append(res)
 
+    // Track a fake url for this page in piwik
+    _paq.push(['setCustomUrl', 'local://names.html/page=' + current_page]);
+    _paq.push(['trackPageView']);
   }
 
   var fragment_obj = get_fragment_obj()

--- a/templates/names.html
+++ b/templates/names.html
@@ -217,6 +217,17 @@ $(function () {
                                                   "key_fields": interesting_names[name_index][4],
                                                   "source_type": source_type});
     modal.find('.modal-content')[0].innerHTML = res
+    _paq.push(['trackEvent', 'modal', 'show'])
+  })
+  $('#modal-for-name').on('hide.bs.modal', function (event) {
+    _paq.push(['trackEvent', 'modal', 'hide'])
+  })
+
+  $('.full_record').on('show.bs.collapse', function (event) {
+    _paq.push(['trackEvent', 'full_record', 'show'])
+  })
+  $('.full_record').on('hide.bs.collapse', function (event) {
+    _paq.push(['trackEvent', 'full_record', 'hide'])
   })
 
   $('.source-checkbox').on('change', function (event) {

--- a/templates/names.html
+++ b/templates/names.html
@@ -189,6 +189,9 @@ $(function () {
     } else {
         var sources_slug = '_';
     }
+    _paq.push(['setCustomDimension', customDimensionId=1, customDimensionValue=wards_slug]);
+    _paq.push(['setCustomDimension', customDimensionId=2, customDimensionValue=sources_slug]);
+    _paq.push(['setCustomDimension', customDimensionId=3, customDimensionValue=search_slug]);
     // Track a fake url for this page in piwik
     _paq.push(['setCustomUrl', 'local://names.html/' + search_slug + '/' + wards_slug + '/' + sources_slug + '/page=' + current_page]);
     _paq.push(['trackPageView']);

--- a/templates/names.html
+++ b/templates/names.html
@@ -192,6 +192,7 @@ $(function () {
     _paq.push(['setCustomDimension', customDimensionId=1, customDimensionValue=wards_slug]);
     _paq.push(['setCustomDimension', customDimensionId=2, customDimensionValue=sources_slug]);
     _paq.push(['setCustomDimension', customDimensionId=3, customDimensionValue=search_slug]);
+    _paq.push(['setCustomDimension', customDimensionId=4, customDimensionValue='{{ date }}']);
     // Track a fake url for this page in piwik
     _paq.push(['setCustomUrl', 'local://names.html/' + search_slug + '/' + wards_slug + '/' + sources_slug + '/page=' + current_page]);
     _paq.push(['trackPageView']);

--- a/templates/names.html
+++ b/templates/names.html
@@ -173,8 +173,24 @@ $(function () {
     var res = nunjucks.render('pager.html', context);
     $("#main").append(res)
 
+
+    if (fragment_obj.sources === undefined) {
+        var search_slug = 'nosearch';
+    } else {
+        var search_slug = 'search';
+    }
+    if (fragment_obj.wards === undefined) {
+        var wards_slug = '_';
+    } else {
+        var wards_slug = fragment_obj.wards.join();
+    }
+    if (fragment_obj.sources === undefined) {
+        var sources_slug = '_';
+    } else {
+        var sources_slug = fragment_obj.sources.join();
+    }
     // Track a fake url for this page in piwik
-    _paq.push(['setCustomUrl', 'local://names.html/page=' + current_page]);
+    _paq.push(['setCustomUrl', 'local://names.html/' + search_slug + '/' + wards_slug + '/' + sources_slug + '/page=' + current_page]);
     _paq.push(['trackPageView']);
   }
 

--- a/templates_nunjucks/name.html
+++ b/templates_nunjucks/name.html
@@ -50,7 +50,7 @@
         <div class="col-md-12">
           <a data-toggle="collapse" href="#full_record_{{ name|lower|replace(" ","_") }}" aria-expanded="false" aria-controls="collapseExample">
           <b>Full record</b></a>
-          <dl class="dl-horizontal collapse" id="full_record_{{ name|lower|replace(" ","_") }}">
+          <dl class="dl-horizontal collapse full_record" id="full_record_{{ name|lower|replace(" ","_") }}">
             {% for term, definition in values[0].data|dictsort %}
               {% if term[0] != "_" and term != "Done" and definition %}
                 <dt>{{term}}</dt> 


### PR DESCRIPTION
Set up piwik analytics (issues: #16 Sprint 2, #49 Sprint 3).

This should now be ready to merge.

## names.html

We disable sending the actual url, as this might send data we don't want to. Instead, we construct fake urls to send to piwik. These include whether it's a text search, what filters are applied, and the page number - but crucially don't include the actual text of the search.

We also track this info as custom dimensions, which gives us more useful filtering/aggregates in Piwik.

One slight oddness is we track a new 'search' every time the results are rerendered, which is currently every time someone types a letter into the search box. It's probably sufficient to look at the analytics with this in mind.

Expanding the full record, or the modal with matches are logged as piwik events. We're deliberately not tracking which record people are clicking on, although we can infer which page it's on.

## areas.html

For areas.html we only track the initial page load.

## Both

I've modified generate_html to insert the current date in the template, so we can track when the copy people are using was generated.

I've disabled tracking outbound links, because this seemed to be leaking our internal urls (containing search terms).

I did try enabling piwik's "heartbeat timer", to accurately record visit duration, but I've removed this again, because as @robredpath suggests (https://github.com/TalkAboutLocal/local-news-engine/issues/16#issuecomment-256962091) we probably want to avoid tracking people leaving the page open but not doing anything with it. Piwik's default 30 minute visit timeout probably works well for us, but this is possible to configure if we'd prefer.

I also looked into piwik's user tracking, but this would require each file we send to a different person to have a different ID in it. For now we're going to see whether piwik's visitor tracking (based on a cookie, so device specific) is sufficient for our needs.