### PR TITLE
Improve the Camden New Journal scraper and entity recognition

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ wget https://opendata.camden.gov.uk/resource/mcgw-i4rx.json
 cd ..
 ```
 
+### Camden New Journal entity recognition
+
+See the top of [camdennewjournal_ner.py](camdennewjournal_ner.py).
+
 
 ## Processing The data
 

--- a/camdennewjournal_ner.py
+++ b/camdennewjournal_ner.py
@@ -9,21 +9,22 @@ from collections import defaultdict
 
 Some setup is required to run this script:
 
-Mirror the site with wget:
-wget -m "http://www.camdennewjournal.com/" -X sites 
+Mirror the site with wget (warning this will take hours):
+```
+# Remove any files that already exist
+rm -r data/www.camdennewjournal.com
+time wget -m "http://www.camdennewjournal.com/" -X sites -P data --restrict-file-names=nocontrol --accept-regex='^http://www.camdennewjournal.com/[^/]*[^\?]*$' 2> data/wget.log
+```
 
-Download nltk data:
-Open up a python prompt and:
-import nltk
-nltk.download()
-d
-punkt
-d
-averaged_perceptron_tagger
-d
-maxent_ne_chunker
-d
-words
+-X sites
+    Exclude anythign under /sites/ - this avoids downloading images/CSS/JS
+-P data
+    Place the downloaded files in the data/ directory
+--restrict-file-names=nocontrol
+    We need this for wget to save UTF-8 filenames properly
+--accept-regex
+    This has a regex to allow http://www.camdennewjournal.com/news?page=1 but not http://www.camdennewjournal.com/news/thisshouldreally404?page=1
+
 
 
 """
@@ -59,11 +60,20 @@ def write_json(entity_names):
     with open('data/saved_camdennewjournal_entities.json', 'w') as fp:
         json.dump(entity_names, fp, default=json_set_default, indent=4, sort_keys=True)
 
+
+# Download required nltk data
+nltk.download('punkt')
+nltk.download('averaged_perceptron_tagger')
+nltk.download('maxent_ne_chunker')
+nltk.download('words')
+
+
+
 entity_names = defaultdict(set)
 i = 0
 
 
-for fname in glob.glob('./www.camdennewjournal.com/**', recursive=True):
+for fname in glob.glob('./data/www.camdennewjournal.com/**', recursive=True):
     if os.path.isdir(fname):
         continue
     try:

--- a/camdennewjournal_summary.py
+++ b/camdennewjournal_summary.py
@@ -3,13 +3,13 @@ import collections
 
 """
 
-python camdennewjournal_summary.py | sort -nr | head -n 1000 | gist -p 
-outputs top 1000 to a gist:
+python camdennewjournal_summary.py | sort -nr | head -n 1000 | gist-paste -p -u d8000e1aa0acccd3cf4665bb0fcc221c
+outputs top 1000 entities with more than one word to a gist:
 https://gist.github.com/Bjwebb/d8000e1aa0acccd3cf4665bb0fcc221c
 
 """
 
-with open('data/camdennewjournal_entities.json') as fp:
+with open('data/saved_camdennewjournal_entities.json') as fp:
     entities = json.load(fp, object_pairs_hook=collections.OrderedDict)
 
 for entity, pages in entities.items():

--- a/load_and_normalize_data.py
+++ b/load_and_normalize_data.py
@@ -232,10 +232,10 @@ def load_camden_journal_data(all_names):
         camden_journal_data = json.load(camden_journal)
 
     for key, value in camden_journal_data.items():
-        for link in value:
+        for data in value:
             all_names[clean_name(key)].append({"source": "Camden New Journal", 
                                                "source_type": "Name",
-                                               "data": {"link": "http://" + link[2:]}})
+                                               "data": data})
 
 
 courts_data = load_courts_data()

--- a/name_matches.py
+++ b/name_matches.py
@@ -41,7 +41,7 @@ for key, value in all_names.items():
     distinct_name_sources = set()
     distinct_data_sources = set()
 
-    value.sort(key=lambda x: x.get('data', {}).get("_recency", ""), reverse=True)
+    value.sort(key=lambda x: x.get('data', {}).get("_recency") or "", reverse=True)
 
 
     for item in value:


### PR DESCRIPTION
#21 (Sprint 2) #46 (Sprint 3)

Improvements to wget command:
- Add more flags to get a cleaner download
- Log wget output
- Output to the data/ directory
- Document the command better

Download required nltk data automatically.

Extract the date from CNJ articles.