### PR TITLE
24 parse new courts data

### DIFF
--- a/courts_parse.py
+++ b/courts_parse.py
@@ -82,17 +82,26 @@ def parse_heading_block(heading_block):
 
 
 def parse_first_case_line(first_case_line):
+    import pprint
+    pprint.pprint(first_case_line)
     data = {"case_order": first_case_line[0]}
 
     gender = p.Suppress(p.Literal("(")) + p.Word(p.alphas, exact=1).setResultsName("gender") + p.Suppress(p.Literal(")"))
 
     dob = p.Suppress(p.Literal("DOB:")) + date.setResultsName("dob") + p.Suppress(p.Literal("Age:")) + p.Word(p.nums).setResultsName("age")
 
+    linked_case = p.Suppress(p.Literal("LINKED CASE"))
+    provisional = p.Suppress(p.Literal("PROVISIONAL"))
+
     first_case_line_detail = p.And([
-        p.SkipTo(gender).setResultsName("name"),
-        gender,
+        #p.Regex(r"([a-zA-Z0-9\ \-]{1,100})").setResultsName("name"),
+        p.SkipTo(p.White(" ", min=10) ^ gender).setResultsName("name"),
+        p.Optional(gender),
         p.Optional(dob),
-        p.Optional(p.Word(p.alphas)).setResultsName("extra_first_line"),
+	p.Optional(linked_case),
+        p.Optional(provisional),
+        #p.Optional(p.Combine(p.OneOrMore(p.Word(p.alphas))).setResultsName("extra_first_line")),
+        #p.Optional(p.SkipTo(p.nums)).setResultsName("first_line_extras"),
         p.Word(p.nums),
     ])
     

--- a/courts_parse.py
+++ b/courts_parse.py
@@ -95,7 +95,7 @@ def parse_first_case_line(first_case_line):
         p.SkipTo(p.White(" ", min=10) ^ gender).setResultsName("name"),
         p.Optional(gender),
         p.Optional(dob),
-	p.Optional(linked_case),
+        p.Optional(linked_case),
         p.Optional(provisional),
         p.Word(p.nums),
     ])

--- a/courts_parse.py
+++ b/courts_parse.py
@@ -101,10 +101,7 @@ def parse_first_case_line(first_case_line):
     ])
     
     for key, value in first_case_line_detail.parseString(first_case_line[1]).asDict().items():
-        if key == "name":
-            data['name'] = value[0].strip()
-        else:
-            data[key] = value.strip()
+    	data[key] = value.strip()
 
     return data
 
@@ -151,7 +148,17 @@ if __name__ == '__main__':
         data = doc.read()
         parsed = parse_court_docs(data)
 
+    safe_output = []
+
+    # Remove juveniles before writing out
+    for case in parsed:
+        if 'age' in case.keys():
+            if int(case['age']) >= 18:
+                safe_output.append(case)
+        elif 'LJA' != "North London Youth Court":
+            safe_output.append(case)
+
     with open("courts_data/courts.json", "w+") as output:
-        json.dump(parsed, output, indent=4)
+        json.dump(safe_output, output, indent=4)
 
 

--- a/courts_parse.py
+++ b/courts_parse.py
@@ -82,8 +82,6 @@ def parse_heading_block(heading_block):
 
 
 def parse_first_case_line(first_case_line):
-    import pprint
-    pprint.pprint(first_case_line)
     data = {"case_order": first_case_line[0]}
 
     gender = p.Suppress(p.Literal("(")) + p.Word(p.alphas, exact=1).setResultsName("gender") + p.Suppress(p.Literal(")"))
@@ -94,14 +92,11 @@ def parse_first_case_line(first_case_line):
     provisional = p.Suppress(p.Literal("PROVISIONAL"))
 
     first_case_line_detail = p.And([
-        #p.Regex(r"([a-zA-Z0-9\ \-]{1,100})").setResultsName("name"),
         p.SkipTo(p.White(" ", min=10) ^ gender).setResultsName("name"),
         p.Optional(gender),
         p.Optional(dob),
 	p.Optional(linked_case),
         p.Optional(provisional),
-        #p.Optional(p.Combine(p.OneOrMore(p.Word(p.alphas))).setResultsName("extra_first_line")),
-        #p.Optional(p.SkipTo(p.nums)).setResultsName("first_line_extras"),
         p.Word(p.nums),
     ])
     


### PR DESCRIPTION
We got a new courts data file, and a couple of things didn't work. There were new tags for cases (LINKED CASE and PROVISIONAL), orgs in court that didn't have DOBs or ages or genders, and *s, for some reason. This deals with all of them, but no guarantees that it's the cleanest approach, so feedback is welcome. 
#24
