### PR TITLE
Remove link tag to CSS that can't be loaded

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -10,8 +10,6 @@
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <link rel="apple-touch-icon" href="apple-touch-icon.png">
-
-        <link rel="stylesheet" href="css/bootstrap.min.css">
         <style>
           .margin-left-10 {
             margin-left: 10px


### PR DESCRIPTION
"css/bootstrap.min.css" can't be loaded as we're running from a local
file.
This isn't a problem because we have the CDN link that does work further
down.
Removing the broken line, so that it doesn't show us in debug log, to
make it obvious that it's not the problem when something else goes
wrong.
